### PR TITLE
Prepare anonymous claps with Cloudflare Worker and D1

### DIFF
--- a/docs/CLOUDFLARE_CLAPS_SETUP.md
+++ b/docs/CLOUDFLARE_CLAPS_SETUP.md
@@ -1,0 +1,37 @@
+# Cloudflare anonymous clap setup
+
+Repository-side preparation is complete. When Cloudflare access is available:
+
+1. Open **Workers & Pages → Create → Worker** and create `jayinlab-claps`.
+2. Open **Storage & Databases → D1 SQL Database → Create** and create `jayinlab-claps`.
+3. In the Worker settings, add a D1 binding:
+   - Variable name: `DB`
+   - Database: `jayinlab-claps`
+4. Add a text variable:
+   - Name: `ALLOWED_ORIGIN`
+   - Value: `https://jayinlab.github.io`
+5. In the D1 console, run `worker/migrations/0001_create_claps.sql`.
+6. Replace the Worker editor content with `worker/src/index.ts` and deploy.
+7. Copy the generated `https://...workers.dev` URL.
+8. In `hugo.toml`, set:
+
+```toml
+[params]
+  description = 'jayinlab blog (Hugo)'
+  clapApiBase = 'https://YOUR-WORKER.YOUR-SUBDOMAIN.workers.dev'
+```
+
+9. Push the Hugo change and let GitHub Pages redeploy.
+
+## Verification
+
+- `GET /health` should return `{ "ok": true }`.
+- Open a post in the `gpu-fun-facts` series.
+- The count should load from D1.
+- A browser can add up to 10 claps per article; its own count is stored in localStorage.
+
+## Notes
+
+- D1 stores only the shared total.
+- localStorage is a convenience limit, not strong abuse prevention.
+- The feature remains disabled until `clapApiBase` is configured.

--- a/hugo.toml
+++ b/hugo.toml
@@ -12,6 +12,8 @@ enableGitInfo = true
 
 [params]
   description = 'jayinlab blog (Hugo)'
+  # Set this after the Cloudflare Worker is deployed.
+  # clapApiBase = 'https://jayinlab-claps.example.workers.dev'
 
 [outputs]
   home = ['HTML', 'RSS']

--- a/layouts/partials/clap.html
+++ b/layouts/partials/clap.html
@@ -1,5 +1,10 @@
-<div class="clap-box" data-clap-key="{{ .RelPermalink }}" aria-label="이 글에 보낸 박수">
-  <button class="clap-button" type="button" data-clap-delta="1" aria-label="박수 하나 추가">👏</button>
+{{- $apiBase := site.Params.clapApiBase | default "" -}}
+<div class="clap-box" data-clap-key="{{ .RelPermalink }}" aria-label="이 글에 보낸 박수"{{ if not $apiBase }} data-disabled="true"{{ end }}>
+  <button class="clap-button" type="button" data-clap-delta="1" aria-label="박수 하나 추가"{{ if not $apiBase }} disabled{{ end }}>👏</button>
   <span class="clap-value" aria-live="polite">0</span>
-  <button class="clap-button" type="button" data-clap-delta="-1" aria-label="박수 하나 취소">➖</button>
+  <button class="clap-button" type="button" data-clap-delta="-1" aria-label="내 박수 하나 취소"{{ if not $apiBase }} disabled{{ end }}>➖</button>
 </div>
+{{- if $apiBase -}}
+<script>document.documentElement.dataset.clapApiBase = {{ $apiBase | jsonify | safeJS }};</script>
+<script src="{{ "js/claps.js" | relURL }}" defer></script>
+{{- end -}}

--- a/static/js/claps.js
+++ b/static/js/claps.js
@@ -1,0 +1,68 @@
+(() => {
+  const MAX_CLAPS_PER_BROWSER = 10;
+  const apiBase = document.documentElement.dataset.clapApiBase?.replace(/\/$/, '');
+  if (!apiBase) return;
+
+  for (const box of document.querySelectorAll('[data-clap-key]')) {
+    const slug = box.dataset.clapKey;
+    const value = box.querySelector('.clap-value');
+    const buttons = box.querySelectorAll('[data-clap-delta]');
+    const storageKey = `jayinlab:claps:${slug}`;
+    let mine = Number(localStorage.getItem(storageKey) || 0);
+    let busy = false;
+
+    const setDisabled = () => {
+      for (const button of buttons) {
+        const delta = Number(button.dataset.clapDelta);
+        button.disabled = busy || (delta === 1 && mine >= MAX_CLAPS_PER_BROWSER) || (delta === -1 && mine <= 0);
+      }
+    };
+
+    const load = async () => {
+      try {
+        const response = await fetch(`${apiBase}/api/claps?slug=${encodeURIComponent(slug)}`);
+        if (!response.ok) throw new Error(`HTTP ${response.status}`);
+        const data = await response.json();
+        value.textContent = String(data.count ?? 0);
+        box.dataset.ready = 'true';
+      } catch (error) {
+        console.warn('Could not load claps', error);
+        box.dataset.error = 'true';
+      }
+      setDisabled();
+    };
+
+    for (const button of buttons) {
+      button.addEventListener('click', async () => {
+        if (busy) return;
+        const delta = Number(button.dataset.clapDelta);
+        if ((delta === 1 && mine >= MAX_CLAPS_PER_BROWSER) || (delta === -1 && mine <= 0)) return;
+
+        busy = true;
+        setDisabled();
+        try {
+          const response = await fetch(`${apiBase}/api/claps`, {
+            method: 'POST',
+            headers: { 'content-type': 'application/json' },
+            body: JSON.stringify({ slug, delta }),
+          });
+          if (!response.ok) throw new Error(`HTTP ${response.status}`);
+          const data = await response.json();
+          mine += delta;
+          localStorage.setItem(storageKey, String(mine));
+          value.textContent = String(data.count ?? 0);
+          box.dataset.error = 'false';
+        } catch (error) {
+          console.warn('Could not update claps', error);
+          box.dataset.error = 'true';
+        } finally {
+          busy = false;
+          setDisabled();
+        }
+      });
+    }
+
+    setDisabled();
+    load();
+  }
+})();

--- a/worker/migrations/0001_create_claps.sql
+++ b/worker/migrations/0001_create_claps.sql
@@ -1,0 +1,8 @@
+CREATE TABLE IF NOT EXISTS article_claps (
+  slug TEXT PRIMARY KEY,
+  count INTEGER NOT NULL DEFAULT 0 CHECK (count >= 0),
+  updated_at INTEGER NOT NULL DEFAULT (unixepoch())
+);
+
+CREATE INDEX IF NOT EXISTS idx_article_claps_count
+  ON article_claps (count DESC);

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -1,0 +1,80 @@
+export interface Env {
+  DB: D1Database;
+  ALLOWED_ORIGIN: string;
+}
+
+const json = (body: unknown, status = 200, origin = '*') =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      'content-type': 'application/json; charset=utf-8',
+      'access-control-allow-origin': origin,
+      'access-control-allow-methods': 'GET, POST, OPTIONS',
+      'access-control-allow-headers': 'content-type',
+      'cache-control': 'no-store',
+    },
+  });
+
+const normalizeSlug = (value: unknown): string | null => {
+  if (typeof value !== 'string') return null;
+  let slug = value.trim();
+  if (!slug.startsWith('/')) slug = `/${slug}`;
+  if (!slug.endsWith('/')) slug = `${slug}/`;
+  if (!/^\/[a-zA-Z0-9/_-]{1,240}\/$/.test(slug)) return null;
+  return slug;
+};
+
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    const allowedOrigin = env.ALLOWED_ORIGIN || 'https://jayinlab.github.io';
+    const requestOrigin = request.headers.get('origin');
+
+    if (request.method === 'OPTIONS') return json({}, 204, allowedOrigin);
+
+    const url = new URL(request.url);
+    if (url.pathname === '/health') return json({ ok: true }, 200, allowedOrigin);
+    if (url.pathname !== '/api/claps') return json({ error: 'not_found' }, 404, allowedOrigin);
+
+    if (request.method === 'GET') {
+      const slug = normalizeSlug(url.searchParams.get('slug'));
+      if (!slug) return json({ error: 'invalid_slug' }, 400, allowedOrigin);
+
+      const row = await env.DB.prepare('SELECT count FROM article_claps WHERE slug = ?')
+        .bind(slug)
+        .first<{ count: number }>();
+      return json({ slug, count: row?.count ?? 0 }, 200, allowedOrigin);
+    }
+
+    if (request.method === 'POST') {
+      if (requestOrigin && requestOrigin !== allowedOrigin) {
+        return json({ error: 'origin_not_allowed' }, 403, allowedOrigin);
+      }
+
+      let payload: { slug?: unknown; delta?: unknown };
+      try {
+        payload = await request.json();
+      } catch {
+        return json({ error: 'invalid_json' }, 400, allowedOrigin);
+      }
+
+      const slug = normalizeSlug(payload.slug);
+      const delta = payload.delta === -1 ? -1 : payload.delta === 1 ? 1 : null;
+      if (!slug || delta === null) return json({ error: 'invalid_request' }, 400, allowedOrigin);
+
+      await env.DB.prepare(`
+        INSERT INTO article_claps (slug, count, updated_at)
+        VALUES (?, MAX(?, 0), unixepoch())
+        ON CONFLICT(slug) DO UPDATE SET
+          count = MAX(article_claps.count + ?, 0),
+          updated_at = unixepoch()
+      `).bind(slug, delta, delta).run();
+
+      const row = await env.DB.prepare('SELECT count FROM article_claps WHERE slug = ?')
+        .bind(slug)
+        .first<{ count: number }>();
+      return json({ slug, count: row?.count ?? 0 }, 200, allowedOrigin);
+    }
+
+    return json({ error: 'method_not_allowed' }, 405, allowedOrigin);
+  },
+};

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -3,15 +3,19 @@ export interface Env {
   ALLOWED_ORIGIN: string;
 }
 
+const corsHeaders = (origin: string) => ({
+  'access-control-allow-origin': origin,
+  'access-control-allow-methods': 'GET, POST, OPTIONS',
+  'access-control-allow-headers': 'content-type',
+});
+
 const json = (body: unknown, status = 200, origin = '*') =>
   new Response(JSON.stringify(body), {
     status,
     headers: {
       'content-type': 'application/json; charset=utf-8',
-      'access-control-allow-origin': origin,
-      'access-control-allow-methods': 'GET, POST, OPTIONS',
-      'access-control-allow-headers': 'content-type',
       'cache-control': 'no-store',
+      ...corsHeaders(origin),
     },
   });
 
@@ -29,7 +33,9 @@ export default {
     const allowedOrigin = env.ALLOWED_ORIGIN || 'https://jayinlab.github.io';
     const requestOrigin = request.headers.get('origin');
 
-    if (request.method === 'OPTIONS') return json({}, 204, allowedOrigin);
+    if (request.method === 'OPTIONS') {
+      return new Response(null, { status: 204, headers: corsHeaders(allowedOrigin) });
+    }
 
     const url = new URL(request.url);
     if (url.pathname === '/health') return json({ ok: true }, 200, allowedOrigin);

--- a/worker/wrangler.jsonc.example
+++ b/worker/wrangler.jsonc.example
@@ -1,0 +1,17 @@
+{
+  "$schema": "node_modules/wrangler/config-schema.json",
+  "name": "jayinlab-claps",
+  "main": "src/index.ts",
+  "compatibility_date": "2026-08-03",
+  "vars": {
+    "ALLOWED_ORIGIN": "https://jayinlab.github.io"
+  },
+  "d1_databases": [
+    {
+      "binding": "DB",
+      "database_name": "jayinlab-claps",
+      "database_id": "PASTE_D1_DATABASE_ID_HERE",
+      "migrations_dir": "migrations"
+    }
+  ]
+}


### PR DESCRIPTION
## What changed

- adds a Cloudflare Worker API for shared clap counts
- adds a D1 migration for article clap totals
- adds a Hugo-side JavaScript client with localStorage-based per-browser limits
- wires the existing clap partial to an optional `clapApiBase` setting
- documents the exact Cloudflare dashboard steps needed later

## Current behavior

The blog remains safe to deploy before Cloudflare is configured. The server-backed clap feature stays disabled until `params.clapApiBase` is set in `hugo.toml`.

## Remaining manual setup

When Cloudflare access is available, follow `docs/CLOUDFLARE_CLAPS_SETUP.md`: create the Worker and D1 database, add the `DB` binding and `ALLOWED_ORIGIN`, run the migration, deploy the Worker code, then paste its URL into `hugo.toml`.

## Validation

Repository structure and Hugo integration were reviewed. Cloudflare runtime deployment cannot be tested until the Worker and D1 resources exist.